### PR TITLE
fix parameter emacs-lisp-mode to emacs-lisp-mode-map

### DIFF
--- a/README.md
+++ b/README.md
@@ -527,7 +527,7 @@ Now your function `foo` is interactive, you can use it in a
 keybinding:
 
 ``` lisp
-(define-key emacs-lisp-mode (kbd "C-c C-f") 'foo)
+(define-key emacs-lisp-mode-mode (kbd "C-c C-f") 'foo)
 ```
 
 ## Defining your own major mode

--- a/README.org
+++ b/README.org
@@ -494,7 +494,7 @@ Now your function `foo` is interactive, you can use it in a
 keybinding:
 
 #+BEGIN_SRC emacs-lisp
-  (define-key emacs-lisp-mode (kbd "C-c C-f") 'foo)
+  (define-key emacs-lisp-mode-map (kbd "C-c C-f") 'foo)
 #+END_SRC
 
 ** Defining your own major mode


### PR DESCRIPTION
Thanks for providing this nice tutorial!
While I was studying Elisp with your tutorial I found one minor typo.
